### PR TITLE
add rolling mean option

### DIFF
--- a/src/camvidlog2/cli.py
+++ b/src/camvidlog2/cli.py
@@ -55,8 +55,8 @@ def query(
     queries: Annotated[list[str], typer.Argument()],
     outdir: Annotated[Path | None, typer.Option()] = None,
     db: Annotated[Path, typer.Option()] = Path("tmp.feather"),
-    num: Annotated[int, typer.Option("--num", "-n")] = 10,
-    roll: Annotated[int, typer.Option("--rolling", "-r")] = 0,
+    num: Annotated[int, typer.Option("--num", "-n", min=0)] = 10,
+    roll: Annotated[int, typer.Option("--rolling", "-r", min=0)] = 0,
 ):
     df = data_load(db)
     if df is None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional parameter to the query command that allows users to apply rolling mean smoothing to similarity scores for improved results.
  - Enforced a minimum value of 0 for the number of results returned in queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->