### PR TITLE
add optional full frame slice

### DIFF
--- a/src/camvidlog2/vid.py
+++ b/src/camvidlog2/vid.py
@@ -433,6 +433,7 @@ def slice_frame_scaling(
     slice_height: int,
     slice_overlap=0.25,
     slice_scaling_max=2.0,
+    full_frame=True,
 ) -> Generator[tuple[Region, np.ndarray], None, None]:
     """Slices a frame into smaller overlapping regions with scaling.
 
@@ -442,6 +443,7 @@ def slice_frame_scaling(
         slice_height (int): Minimum height of each slice in pixels
         slice_overlap (float): Proportion of overlap between slices. Defaults to 0.25
         slice_scaling_max (float): Maximum scaling factor for slice size. Defaults to 2.0
+        full_frame (bool): If True, also yield the original frame as a slice. Defaults to True
 
     Yields:
         tuple[Region, np.ndarray]: A tuple containing (region, subframe)
@@ -499,3 +501,8 @@ def slice_frame_scaling(
             int(slice_height * (frame_width / slice_width)),
             slice_overlap,
         )
+
+    if full_frame:
+        # yield the full frame as a slice
+        # might not match the aspect ratio
+        yield Region(0, 0, frame_width, frame_height), frame

--- a/src/camvidlog2/vid.py
+++ b/src/camvidlog2/vid.py
@@ -431,9 +431,10 @@ def slice_frame_scaling(
     frame: np.ndarray,
     slice_width: int,
     slice_height: int,
-    slice_overlap=0.25,
-    slice_scaling_max=2.0,
-    full_frame=True,
+    *,
+    slice_overlap: float = 0.25,
+    slice_scaling_max: float = 2.0,
+    full_frame: bool = True,
 ) -> Generator[tuple[Region, np.ndarray], None, None]:
     """Slices a frame into smaller overlapping regions with scaling.
 

--- a/src/camvidlog2/yoloe/ai.py
+++ b/src/camvidlog2/yoloe/ai.py
@@ -191,6 +191,7 @@ def generate_tracked_bboxes(
                 slice_height=640,
                 slice_overlap=slice_overlap,
                 slice_scaling_max=slice_scaling,
+                full_frame=True,  # include full frame as a slice
             ),
             max_batch_size,
             strict=False,  # will pad the last batch later if needed

--- a/test/test_vid.py
+++ b/test/test_vid.py
@@ -111,7 +111,9 @@ def test_slice_frame():
 def test_slice_frame_scaling():
     frame = np.zeros((800, 1000, 3), dtype=np.uint8)
     slice_size = 400
-    slices = slice_frame_scaling(frame, slice_size, slice_size, 0.25, 2.0)
+    slices = slice_frame_scaling(
+        frame, slice_size, slice_size, 0.25, 2.0, full_frame=False
+    )
 
     # 9 of 400x400 slices
     # 4 of 632x632 slices

--- a/test/test_vid.py
+++ b/test/test_vid.py
@@ -112,7 +112,12 @@ def test_slice_frame_scaling():
     frame = np.zeros((800, 1000, 3), dtype=np.uint8)
     slice_size = 400
     slices = slice_frame_scaling(
-        frame, slice_size, slice_size, 0.25, 2.0, full_frame=False
+        frame,
+        slice_size,
+        slice_size,
+        slice_overlap=0.25,
+        slice_scaling_max=2.0,
+        full_frame=False,
     )
 
     # 9 of 400x400 slices


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include the entire frame as an additional slice during frame slicing operations.
* **Bug Fixes**
  * Adjusted object detection processing to include the full frame as a slice.
* **Tests**
  * Updated tests to allow toggling the inclusion of the full frame in slicing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->